### PR TITLE
Fix error when run ./1_bench.sh accuracy

### DIFF
--- a/scripts/1_bench.sh
+++ b/scripts/1_bench.sh
@@ -64,7 +64,6 @@ if [ $1 == "perf" ] || [ $1 == "all" ] || [ $1 == "submit" ]; then
 
     PERF_OUTPUT=$(python show_results.py)
     echo "$PERF_OUTPUT"
-    fi
 fi
 
 


### PR DESCRIPTION
ERROR DESCRIPTION

root@9a65aff2f9ef:/workspace# ./1_bench.sh accuracy
./1_bench.sh: line 68: syntax error near unexpected token `fi'
./1_bench.sh: line 68: `fi'